### PR TITLE
Feature/routes

### DIFF
--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -8,13 +8,6 @@ import Footer from 'components/layout/footer';
 import Head from 'components/layout/head';
 import Icons from 'components/layout/icons';
 
-/* eslint-disable */
-if (process.env.NODE_ENV !== 'production') {
-  const { whyDidYouUpdate } = require('why-did-you-update');
-  whyDidYouUpdate(React);
-}
-/* eslint-enable */
-
 export default function Layout(props) {
   const { title, children, className } = props;
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const express = require('express');
 const next = require('next');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
+const routes = require('./routes');
 
 // Load environment variables from .env file if present
 require('dotenv').load();
@@ -29,12 +30,9 @@ process.on('unhandledRejection', (reason, p) => {
 process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 process.env.PORT = process.env.PORT || 80;
 
-const app = next({
-  dir: '.',
-  dev
-});
+const app = next({ dir: '.', dev });
 
-const handle = app.getRequestHandler();
+const handle = routes.getRequestHandler(app);
 
 // Express app creation
 const server = express();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2252,12 +2252,12 @@
             }
           }
         },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true
-        },
         "string_decoder": {
           "version": "0.10.31",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
           "bundled": true
         },
         "stringstream": {
@@ -4388,6 +4388,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
       "integrity": "sha1-VGpRdBrVprB+njGwsQRBqRffUoo="
     },
+    "string_decoder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
+    },
     "string-hash": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.1.tgz",
@@ -4402,11 +4407,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
-    },
-    "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -4761,20 +4761,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-    },
-    "why-did-you-update": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/why-did-you-update/-/why-did-you-update-0.0.8.tgz",
-      "integrity": "sha1-OJ2X3WwUfh7byfXVRw1E2YXIrjg=",
-      "dev": true,
-      "dependencies": {
-        "lodash": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz",
-          "integrity": "sha1-K9bcRqBA9Z5obJcu0h2T3FkFMlg=",
-          "dev": true
-        }
-      }
     },
     "wide-align": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-import": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
     "eslint-plugin-react": "^6.10.3",
-    "extract-text-webpack-plugin": "^2.1.0",
-    "why-did-you-update": "0.0.8"
+    "extract-text-webpack-plugin": "^2.1.0"
   },
   "scripts": {
     "dev": "NODE_ENV=development node index.js",

--- a/pages/Home.js
+++ b/pages/Home.js
@@ -1,10 +1,17 @@
 import React from 'react';
+import { Link } from 'routes';
 import Layout from 'components/layout/layout';
 
 export default function HomePage() {
   return (
     <Layout title="Home">
       Hi there! Welcome to Sustainable Cities!
+      <br />
+      <Link route="explore-index">Explore index page</Link>
+      <br />
+      <Link route="explore-list" params={{ category: 'solutions', subCategory: 'bike-sharing' }}>Explore list page</Link>
+      <br />
+      <Link route="explore-detail" params={{ category: 'solutions', slug: 'bicimad', id: 1 }}>Explore detail page</Link>
     </Layout>
   );
 }

--- a/pages/explore/ExploreDetail.js
+++ b/pages/explore/ExploreDetail.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Layout from 'components/layout/layout';
+
+export default class ExploreDetail extends React.Component {
+  static async getInitialProps({ query }) {
+    return {
+      category: query.category,
+      slug: query.slug,
+      id: query.id
+    };
+  }
+
+  render() {
+    return (
+      <Layout title="Explore detail">
+        <h1>Explore list</h1>
+        <strong>Category: </strong> {this.props.category}<br />
+        <strong>Slug: </strong> {this.props.slug}<br />
+        <strong>Id: </strong> {this.props.id}
+      </Layout>
+    );
+  }
+}
+
+ExploreDetail.propTypes = {
+  category: PropTypes.string.isRequired,
+  slug: PropTypes.string.isRequired,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
+};

--- a/pages/explore/ExploreIndex.js
+++ b/pages/explore/ExploreIndex.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Layout from 'components/layout/layout';
+
+export default class ExploreIndex extends React.Component {
+  static async getInitialProps({ query }) {
+    return {
+      category: query.category,
+      subCategory: query.subCategory
+    };
+  }
+
+  render() {
+    return (
+      <Layout title="Explore">
+        <h1>Explore Index</h1>
+        <strong>Category?: </strong> {this.props.category || '–'}<br />
+        <strong>Sub-category?: </strong> {this.props.subCategory || '–'}
+      </Layout>
+    );
+  }
+}
+
+ExploreIndex.propTypes = {
+  category: PropTypes.string,
+  subCategory: PropTypes.string
+};

--- a/pages/explore/ExploreList.js
+++ b/pages/explore/ExploreList.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Layout from 'components/layout/layout';
+
+export default class ExploreList extends React.Component {
+  static async getInitialProps({ query }) {
+    return {
+      category: query.category,
+      subCategory: query.subCategory
+    };
+  }
+
+  render() {
+    return (
+      <Layout title="Explore list">
+        <h1>Explore list</h1>
+        <strong>Category: </strong> {this.props.category}<br />
+        <strong>Sub-category: </strong> {this.props.subCategory}
+      </Layout>
+    );
+  }
+}
+
+ExploreList.propTypes = {
+  category: PropTypes.string.isRequired,
+  subCategory: PropTypes.string.isRequired
+};

--- a/routes.js
+++ b/routes.js
@@ -2,3 +2,8 @@
 
 const nextRoutes = require('next-routes');
 const routes = module.exports = nextRoutes();
+
+// EXPLORE
+routes.add('explore-index', '/explore/:category?/:subCategory?', 'explore/ExploreIndex');
+routes.add('explore-list', '/explore/list/:category/:subCategory', 'explore/ExploreList');
+routes.add('explore-detail', '/explore/detail/:category/:slug/:id', 'explore/ExploreDetail');


### PR DESCRIPTION
This PR defines the routes of the explore section of the app.

<hr />

### Index route: `/explore/:category?/:subCategory?`

This route works with these examples:
1. `/explore` ⤵
2. `/explore/solutions` ⤵
3. `/explore/solutions/bike-sharing`

The idea is that if the page is entered using route `1.` or `2.`, the route will be completed with the category and sub-category when the page loads.

The route `1.` would be the link the homepage has towards the explore section: the homepage doesn't know anything about the categories and sub-categories, hence it triggers the routing without any parameter.

The route `2.` is used in the header: when the user clicks the "explore" item, a dropdown appears with the list of categories. The header doesn't know about the sub-categories, so it's not present in the URL.

The route `3.` will be used inside the explore index page itself when the user filters the map and lists.

### List route: `/explore/list/:category/:subCategory`

An example of this route is: `/explore/list/solutions/bike-sharing`.

This page lists all the projects or business models of a category and sub-category. For the `cities` category, the list of sub-categories will be either regions **[1]** or cities **[2]**.

**[1]** According to the filters on the explore index page, the sub-categories are regions of the world.
**[2]** Nevertheless, it seems like sub-categories can also be [cities](https://projects.invisionapp.com/d/main/default/#/console/11110736/235030616/preview).


### Detail route: `/explore/detail/:category/:slug/:id`

An example of route could be: `/explore/detail/solutions/bicimad/1`.

This route doesn't follow the pattern `/:category/:subCategory` to avoid having long URLs. Ideally, the route would be without any category, but the page has to show two types of entities (either business models or projects) and it seems the API doesn't have unique IDs for them (we can have a business model with ID 1 and a project with ID 1 too). For this reason, the category can let us know whether we need to load a business model or a project. **I'm open to suggestions here.**

We would fetch the entity using the ID, so the slug is quite useless, nevertheless, I think it's a good idea to keep it in order to have a better referencing.

<hr />

In addition to the routes, the PR removes the package `why-did-you-update` because it would throw several warnings in the console each time a route is navigated.

**NOTE:** it seems like `next-routes` actually uses a depecrated way to declare the routes and next displays some warnings because of it. I couldn't find any issue related to this in the repository.