### PR TITLE
Feature/grid list

### DIFF
--- a/components/common/GridItem.js
+++ b/components/common/GridItem.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+export default function GridItem(props) {
+  const isExternalLink = props.link && /^https?/.test(props.link);
+  const linkAttributes = {
+    href: props.link,
+    rel: 'noopener',
+    target: isExternalLink ? '_blank' : '_self'
+  };
+
+  return (
+    <a // eslint-disable-line jsx-a11y/no-static-element-interactions
+      {...(props.link ? linkAttributes : {})}
+      role="link"
+      onClick={() => props.onClick && props.onClick()}
+      className="c-grid-item"
+    >
+      <div className="background" />
+      <div
+        className={classnames('image', `-${props.imageLayout}`)}
+        style={props.image && { backgroundImage: `url(${props.image})` }}
+      />
+      <div className={classnames('title', { '-small': props.imageLayout === 'portrait' })}>{props.title}</div>
+      { props.subtitle && <div className="subtitle">{props.subtitle}</div> }
+    </a>
+  );
+}
+
+GridItem.propTypes = {
+  image: PropTypes.string,
+  imageLayout: PropTypes.oneOf(['landscape', 'portrait']),
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
+  onClick: PropTypes.func,
+  link: PropTypes.string
+};
+
+GridItem.defaultProps = {
+  imageLayout: 'landscape'
+};

--- a/components/common/GridItem.js
+++ b/components/common/GridItem.js
@@ -1,18 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { Link } from 'routes';
 
 export default function GridItem(props) {
-  const isExternalLink = props.link && /^https?/.test(props.link);
-  const linkAttributes = {
-    href: props.link,
-    rel: 'noopener',
-    target: isExternalLink ? '_blank' : '_self'
-  };
+  // If the link is a string, this means that it is external
+  const isExternalLink = typeof props.link === 'string';
 
-  return (
+  const linkAttributes = isExternalLink
+    ? { href: props.link, rel: 'noopener', target: '_blank' }
+    : {};
+
+  const content = (
     <a // eslint-disable-line jsx-a11y/no-static-element-interactions
-      {...(props.link ? linkAttributes : {})}
+      {...linkAttributes}
       role="link"
       onClick={() => props.onClick && props.onClick()}
       className="c-grid-item"
@@ -26,6 +27,16 @@ export default function GridItem(props) {
       { props.subtitle && <div className="subtitle">{props.subtitle}</div> }
     </a>
   );
+
+  if (!props.link || isExternalLink) {
+    return content;
+  }
+
+  return (
+    <Link route={props.link.route} params={props.link.params}>
+      {content}
+    </Link>
+  );
 }
 
 GridItem.propTypes = {
@@ -34,7 +45,13 @@ GridItem.propTypes = {
   title: PropTypes.string.isRequired,
   subtitle: PropTypes.string,
   onClick: PropTypes.func,
-  link: PropTypes.string
+  link: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      route: PropTypes.string.isRequired,
+      params: PropTypes.object
+    })
+  ])
 };
 
 GridItem.defaultProps = {

--- a/components/common/GridItem.js
+++ b/components/common/GridItem.js
@@ -8,7 +8,7 @@ export default function GridItem(props) {
   const isExternalLink = typeof props.link === 'string';
 
   const linkAttributes = isExternalLink
-    ? { href: props.link, rel: 'noopener', target: '_blank' }
+    ? { href: props.link, rel: 'noreferrer', target: '_blank' }
     : {};
 
   const content = (

--- a/components/common/GridList.js
+++ b/components/common/GridList.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Components
+import GridItem from 'components/common/GridItem';
+
+export default function GridList(props) {
+  return (
+    <div className="c-grid-list row align-stretch">
+      { props.items.map(item => (
+        <div className="column small-3" key={item.title}>
+          <GridItem
+            image={item.image}
+            imageLayout={props.layout || item.layout}
+            title={item.title}
+            subtitle={item.subtitle}
+            link={item.link}
+            onClick={props.onClick || item.onClick}
+          />
+        </div>
+      )) }
+    </div>
+  );
+}
+
+GridList.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.shape(GridItem.propTypes)).isRequired,
+  layout: GridItem.propTypes.imageLayout, // eslint-disable-line react/no-unused-prop-types
+  onClick: GridItem.propTypes.onClick
+};

--- a/css/components/common/_grid-item.scss
+++ b/css/components/common/_grid-item.scss
@@ -1,0 +1,61 @@
+.c-grid-item {
+  display: block;
+  position: relative;
+  text-decoration: none;
+
+  &:hover {
+    z-index: 1;
+
+    .background {
+      transform: scale(1.2);
+      background-color: $color-white;
+      box-shadow: 0 7px 15px 0 rgba($color-black, .15);
+    }
+  }
+
+  .background {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: transparent;
+    transition: transform .3s, background-color .3s, box-shadow .3s;
+    content: '';
+    z-index: -1;
+  }
+
+  .image {
+    display: block;
+    width: 100%;
+    height: 130px;
+    margin-bottom: 10px;
+    background-size: cover;
+    background-position: center center;
+    background-color: $color-4;
+
+    &.-portrait {
+      height: 310px;
+    }
+  }
+
+  .title {
+    font-size: $font-size-bigger;
+    font-weight: $font-weight-light;
+    line-height: 1.3;
+    color: $color-text-1;
+
+    &.-small {
+      font-size: $font-size-big;
+    }
+  }
+
+  .subtitle {
+    font-size: $font-size-smaller;
+    text-transform: uppercase;
+    color: $color-text-2;
+    line-height: 1.3;
+  }
+
+}

--- a/css/components/common/_grid-list.scss
+++ b/css/components/common/_grid-list.scss
@@ -1,0 +1,11 @@
+.c-grid-list {
+
+  .column {
+    margin: 25px 0;
+  }
+
+  .c-grid-item {
+    height: 100%;
+  }
+
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -3,6 +3,11 @@
 // Reset
 @import '../node_modules/normalize.css/normalize';
 
+// Foundation styles
+@import 'foundation-sites/scss/foundation';
+@include foundation-flex-classes;
+@include foundation-flex-grid;
+
 // Common
 @import 'base';
 @import 'font';
@@ -11,7 +16,8 @@
 
 // Components
 // - layout
-// @import 'components/layout/header';
+@import 'components/common/grid-item';
+@import 'components/common/grid-list';
 
 // - page
 // @import 'components/page/section';

--- a/css/index.scss
+++ b/css/index.scss
@@ -1,9 +1,7 @@
 @import 'settings';
 
-// Reset
-@import '../node_modules/normalize.css/normalize';
-
 // Foundation styles
+// NOTE: normalize is included with foundation
 @import 'foundation-sites/scss/foundation';
 @include foundation-flex-classes;
 @include foundation-flex-grid;

--- a/css/settings.scss
+++ b/css/settings.scss
@@ -64,7 +64,7 @@ $font-weight-bold:    700;
  * LAYOUT
 */
 // Max widths
-$layout-max-width: 1060px;
+$layout-max-width: 1080px;
 
 // Responsive breakpoints
 // $br-mobile: 640px;

--- a/css/settings.scss
+++ b/css/settings.scss
@@ -48,7 +48,8 @@ $font-size-extrasmall:  12px;
 $font-size-smaller:     14px;
 $font-size-small:       15px;
 $font-size-default:     16px;
-$font-size-big:         22px;
+$font-size-medium:      22px;
+$font-size-big:         24px;
 $font-size-bigger:      28px;
 $font-size-extrabig:    32px;
 $font-size-huge:        64px;
@@ -63,7 +64,7 @@ $font-weight-bold:    700;
  * LAYOUT
 */
 // Max widths
-// $layout-max-width: 1060px;
+$layout-max-width: 1060px;
 
 // Responsive breakpoints
 // $br-mobile: 640px;
@@ -94,3 +95,13 @@ $font-weight-bold:    700;
 // $ease-in-sine: cubic-bezier(0.470, 0.000, 0.745, 0.715);
 // $ease-out-sine: cubic-bezier(0.390, 0.575, 0.565, 1.000);
 // $ease-in-out-sine: cubic-bezier(0.445, 0.050, 0.550, 0.950);
+
+/**
+ * FOUNDATION
+ */
+$base-font-size: $font-size-default;
+$global-width: $layout-max-width;
+$grid-column-gutter: (
+  small:  20px,
+  medium: 20px
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1760,6 +1760,11 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
       "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
     },
+    "foundation-sites": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.3.1.tgz",
+      "integrity": "sha1-I4Uzct65SAwTtCZJnq8Mj5DNvh0="
+    },
     "fresh": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
@@ -2852,6 +2857,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jquery": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
     },
     "js-base64": {
       "version": "2.1.9",
@@ -4746,6 +4756,11 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
       "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s="
+    },
+    "what-input": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/what-input/-/what-input-4.1.3.tgz",
+      "integrity": "sha1-OJjJK0Tv9Io0xjcfOmnTcw6nxYg="
     },
     "whatwg-fetch": {
       "version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3386,11 +3386,6 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
-    "normalize.css": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-7.0.0.tgz",
-      "integrity": "sha1-q/sd2CRwZ04DIrU86xqvQSk45L8="
-    },
     "now-logs": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/now-logs/-/now-logs-0.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "next-redux-wrapper": "^1.1.2",
     "next-routes": "^1.0.24",
     "node-sass": "^4.5.0",
-    "normalize.css": "^7.0.0",
     "now-logs": "0.0.7",
     "orm": "^3.2.3",
     "postcss-easy-import": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eventemitter3": "^2.0.3",
     "express": "^4.14.0",
     "express-session": "^1.14.2",
+    "foundation-sites": "^6.3.1",
     "glob": "7.1.1",
     "isomorphic-fetch": "^2.2.1",
     "json-api-normalizer": "^0.4.0",

--- a/pages/explore/ExploreList.js
+++ b/pages/explore/ExploreList.js
@@ -17,15 +17,23 @@ export default class ExploreList extends React.Component {
     const sample = [
       {
         title: 'Capital Bikeshare',
-        subtitle: 'Washington DC'
+        subtitle: 'Washington DC',
+        link: 'https://www.duckduckgo.com'
       },
       {
         title: 'Citi Bike',
-        subtitle: 'NYC'
+        subtitle: 'NYC',
+        link: {
+          route: 'explore-index'
+        }
       },
       {
         title: 'Divvy',
-        subtitle: 'Chicago'
+        subtitle: 'Chicago',
+        link: {
+          route: 'explore-detail',
+          params: { category: 'bike-sharing', slug: 'divyy', id: 3 }
+        }
       },
       {
         title: 'Hubway',

--- a/pages/explore/ExploreList.js
+++ b/pages/explore/ExploreList.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Layout from 'components/layout/layout';
 
+// Components
+import GridList from 'components/common/GridList';
+
 export default class ExploreList extends React.Component {
   static async getInitialProps({ query }) {
     return {
@@ -11,11 +14,35 @@ export default class ExploreList extends React.Component {
   }
 
   render() {
+    const sample = [
+      {
+        title: 'Capital Bikeshare',
+        subtitle: 'Washington DC'
+      },
+      {
+        title: 'Citi Bike',
+        subtitle: 'NYC'
+      },
+      {
+        title: 'Divvy',
+        subtitle: 'Chicago'
+      },
+      {
+        title: 'Hubway',
+        subtitle: 'Boston'
+      },
+      {
+        title: 'BiciMad',
+        subtitle: 'Madrid'
+      }
+    ];
+
     return (
       <Layout title="Explore list">
         <h1>Explore list</h1>
         <strong>Category: </strong> {this.props.category}<br />
         <strong>Sub-category: </strong> {this.props.subCategory}
+        <GridList items={sample} />
       </Layout>
     );
   }


### PR DESCRIPTION
This PR adds two new components: `GridItem` and `GridList`.

<img width="1116" alt="Example of a list of cards" src="https://user-images.githubusercontent.com/6073968/27047817-60e67a64-4fa1-11e7-986a-1a9d03169c15.png">


`GridItem` renders a "card" with a title, a subtitle and an image (portrait or landscape). If the component receives an `onClick` prop, then it will be triggered when it's clicked. If it receives a `link` prop, the link will be opened in the same tab or another depending on if it's an external link.

`GridList` renders a list of `GridItem` components. In addition to `items`, it can receive the props `layout`and `onClick` to set the layout and click handler to all the cards at once.

Apart from the two components, the PR also changes two font sizes: `$font-size-big` becomes `$font-size-medium` and `$font-size-big` gets a new value.

Finally, the linting has been disabled for some lines because of issues of the linter (the code issues have actually been fixed).