### PR TITLE
Implement the Cover component

### DIFF
--- a/components/common/Breadcrumbs.js
+++ b/components/common/Breadcrumbs.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Breadcrumbs() {
+  return (
+    <div>Breadcrumbs</div>
+  );
+}

--- a/components/common/Cover.js
+++ b/components/common/Cover.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+// Components
+import Breadcrumbs from 'components/common/Breadcrumbs';
+
+export default function Cover(props) {
+  return (
+    <div
+      className={classnames('c-cover', `-${props.size}`)}
+      style={props.image && { backgroundImage: `url(${props.image})` }}
+    >
+      <div className="row align-bottom">
+        <div className="column large-8">
+          { props.breadcrumbs && <div className="breadcrumbs">{props.breadcrumbs}</div> }
+          <h1>{props.title}</h1>
+          { props.description && <p className="description">{props.description}</p> }
+        </div>
+        <div className="column large-4">
+          <div className={classnames('actions', { '-margin': !props.description })}>
+            {props.children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Cover.propTypes = {
+  image: PropTypes.string,
+  size: PropTypes.oneOf(['normal', 'short']),
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  breadcrumbs: PropTypes.instanceOf(Breadcrumbs),
+  children: PropTypes.any
+};
+
+Cover.defaultProps = {
+  size: 'normal'
+};

--- a/css/components/common/_cover.scss
+++ b/css/components/common/_cover.scss
@@ -1,0 +1,43 @@
+.c-cover {
+  height: 440px;
+  padding: 50px 0;
+  background-size: cover;
+  background-position: center center;
+  background-color: $color-2;
+
+  &.-short {
+    height: 300px;
+    padding: 25px 0;
+  }
+
+  > .row {
+    height: 100%;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: $font-size-huge;
+    font-weight: $font-weight-thin;
+    color: $color-text-4;
+    line-height: 1.15;
+  }
+
+  .description {
+    margin: 10px 0 0 0;
+    color: $color-text-4;
+  }
+
+  .breadcrumbs {
+    margin-bottom: 7px;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+
+    &.-margin {
+      margin-bottom: 14px;
+    }
+  }
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -31,3 +31,4 @@
 @import 'components/common/grid-item'; // Must be before the other grid components
 @import 'components/common/grid-list';
 @import 'components/common/grid-slider';
+@import 'components/common/cover';

--- a/pages/explore/ExploreIndex.js
+++ b/pages/explore/ExploreIndex.js
@@ -4,15 +4,22 @@ import PropTypes from 'prop-types';
 // components
 import Page from 'pages/Page';
 import Layout from 'components/layout/layout';
+import Cover from 'components/common/Cover';
 
 export default class ExploreIndex extends Page {
   render() {
     const { category, subCategory } = this.props.queryParams;
+
+    // This is a temporary variable to show some content
+    // eslint-disable-next-line
+    const description = `Solution description lorem ipusm casius tesebe erat a ante venenatis dapibus posuere velit aliquet. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Etiam porta sem malesuada magna mollis euismod. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.`;
+
     return (
       <Layout
         title="Explore"
         queryParams={this.props.queryParams}
       >
+        <Cover title="Explore" description={description} />
         <h1>Explore Index</h1>
         <strong>Category?: </strong> {category || '–'}<br />
         <strong>Sub-category?: </strong> {subCategory || '–'}


### PR DESCRIPTION
This PR adds a new component: `Cover`.

<img width="1678" alt="Screenshot of the new component" src="https://user-images.githubusercontent.com/6073968/27292181-8fafb130-550a-11e7-88c6-6e28b40f6458.png">

The component accepts as props:
- `title` (mandatory)
- `description`
- `size`: either `normal` (default) or `short`
- `breadcrumbs`: an instance of the `Breadcrumbs` component
- `children`: whatever buttons will be on the side of the component (will be aligned right, at the bottom)