### PR TITLE
Feature/breadcrumbs

### DIFF
--- a/components/common/Breadcrumbs.js
+++ b/components/common/Breadcrumbs.js
@@ -1,7 +1,35 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'routes';
 
-export default function Breadcrumbs() {
+export default function Breadcrumbs(props) {
   return (
-    <div>Breadcrumbs</div>
+    <ul className="c-breadcrumbs">
+      {props.items.map((item) => { // eslint-disable-line arrow-body-style
+        return (
+          <li key={item.name}>
+            <Link route={item.route} params={item.params}>
+              <a>
+                {item.name}
+              </a>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
   );
 }
+
+Breadcrumbs.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      route: PropTypes.string.isRequired,
+      params: PropTypes.object
+    })
+  )
+};
+
+Breadcrumbs.defaultProps = {
+  items: []
+};

--- a/components/common/Cover.js
+++ b/components/common/Cover.js
@@ -2,9 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-// Components
-import Breadcrumbs from 'components/common/Breadcrumbs';
-
 export default function Cover(props) {
   return (
     <div
@@ -32,7 +29,7 @@ Cover.propTypes = {
   size: PropTypes.oneOf(['normal', 'short']),
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
-  breadcrumbs: PropTypes.instanceOf(Breadcrumbs),
+  breadcrumbs: PropTypes.PropTypes.element, // Breadcrumbs component expected
   children: PropTypes.any
 };
 

--- a/css/components/common/_breadcrumbs.scss
+++ b/css/components/common/_breadcrumbs.scss
@@ -1,0 +1,23 @@
+.c-breadcrumbs {
+  li {
+    font-size: $font-size-extrasmall;
+    font-weight: $font-weight-bold;
+    line-height: 1.25;
+    color: $color-primary;
+
+    &:not(:last-of-type)::after {
+      display: inline-block;
+      margin: 0 1ch;
+      content: '/';
+    }
+
+    a {
+      font-size: $font-size-extrasmall;
+      font-weight: $font-weight-bold;
+      text-transform: uppercase;
+      line-height: 1.25;
+      letter-spacing: 1px;
+      color: $color-primary;
+    }
+  }
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -33,3 +33,4 @@
 @import 'components/common/grid-list';
 @import 'components/common/grid-slider';
 @import 'components/common/cover';
+@import 'components/common/breadcrumbs';

--- a/pages/explore/ExploreDetail.js
+++ b/pages/explore/ExploreDetail.js
@@ -1,18 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+// Constants
+import { EXPLORE_TABS } from 'constants/explore';
+
 // components
 import Page from 'pages/Page';
 import Layout from 'components/layout/layout';
+import Cover from 'components/common/Cover';
+import Breadcrumbs from 'components/common/Breadcrumbs';
 
 export default class ExploreDetail extends Page {
+
+  static getCategory(slug) {
+    return EXPLORE_TABS.find(category => category.query.category === slug);
+  }
+
   render() {
     const { category, id, slug } = this.props.queryParams;
+
+    const categoryItem = ExploreDetail.getCategory(category);
+    const breadcrumbs = (
+      <Breadcrumbs
+        items={[
+          {
+            name: categoryItem.label,
+            route: 'explore-index',
+            params: { category }
+          }
+        ]}
+      />
+    );
+
     return (
       <Layout
         title="Explore detail"
         queryParams={this.props.queryParams}
       >
+        <Cover title={id} breadcrumbs={breadcrumbs} />
+
         <h1>Explore list</h1>
         <strong>Category: </strong> {category}<br />
         <strong>Slug: </strong> {slug}<br />
@@ -23,7 +49,5 @@ export default class ExploreDetail extends Page {
 }
 
 ExploreDetail.propTypes = {
-  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  queryParams: PropTypes.object.isRequired,
-  slug: PropTypes.string.isRequired
+  queryParams: PropTypes.object.isRequired
 };

--- a/pages/explore/ExploreList.js
+++ b/pages/explore/ExploreList.js
@@ -1,14 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+// Constants
+import { EXPLORE_TABS } from 'constants/explore';
+
 // Components
 import Page from 'pages/Page';
 import Layout from 'components/layout/layout';
 import GridList from 'components/common/GridList';
 import GridSlider from 'components/common/GridSlider';
+import Cover from 'components/common/Cover';
+import Breadcrumbs from 'components/common/Breadcrumbs';
 
 export default class ExploreList extends Page {
+
+  static getCategory(slug) {
+    return EXPLORE_TABS.find(category => category.query.category === slug);
+  }
+
   render() {
+    const { category, subCategory } = this.props.queryParams;
+
     const sample = [
       {
         title: 'Capital Bikeshare',
@@ -40,14 +52,29 @@ export default class ExploreList extends Page {
       }
     ];
 
+    const categoryItem = ExploreList.getCategory(category);
+    const breadcrumbs = (
+      <Breadcrumbs
+        items={[
+          {
+            name: categoryItem.label,
+            route: 'explore-index',
+            params: { category }
+          }
+        ]}
+      />
+    );
+
     return (
       <Layout
         title="Explore list"
         queryParams={this.props.queryParams}
       >
+        <Cover title={subCategory} breadcrumbs={breadcrumbs} />
+
         <h1>Explore list</h1>
-        <strong>Category: </strong> {this.props.category}<br />
-        <strong>Sub-category: </strong> {this.props.subCategory}
+        <strong>Category: </strong> {category}<br />
+        <strong>Sub-category: </strong> {subCategory}
         <GridList items={sample} />
         <GridSlider items={[...sample, ...sample]} layout="portrait" />
       </Layout>


### PR DESCRIPTION
This PR adds the `Breadcrumbs` component.

<img width="1680" alt="Screenshot of the component" src="https://user-images.githubusercontent.com/6073968/27297679-c93dfe94-551d-11e7-95bb-ec74249ade9d.png">

To maximise its flexibility, the component doesn't determine its content but rather delegates the work to its parent page. The explore detail and explore list pages will then need to determine the information to display in the breadcrumbs.

As the information will come from the API, the templates only show the top-level category for now.

NOTE: the `Cover` component has also be updated because one of the prop types define there was wrong.