### PR TITLE
Implement the Button component

### DIFF
--- a/components/common/Button.js
+++ b/components/common/Button.js
@@ -8,7 +8,8 @@ export default function Button(props) {
     'c-button': true,
     '-primary': !props.secondary,
     '-secondary': props.secondary,
-    '-inverse': props.inverse
+    '-inverse': props.inverse,
+    '-disabled': props.disabled
   });
 
   if (props.link) {
@@ -63,10 +64,12 @@ Button.propTypes = {
   ]),
   onClick: PropTypes.func,
   secondary: PropTypes.bool,
-  inverse: PropTypes.bool
+  inverse: PropTypes.bool,
+  disabled: PropTypes.bool
 };
 
 Button.defaultProps = {
   secondary: false,
-  inverse: false
+  inverse: false,
+  disabled: false
 };

--- a/components/common/Button.js
+++ b/components/common/Button.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { Link } from 'routes';
+
+export default function Button(props) {
+  const classes = ['c-button'];
+
+  // We add the classes
+  if (props.secondary) classes.push('-secondary');
+  else classes.push('-primary');
+
+  if (props.inverse) classes.push('-inverse');
+
+  if (props.link) {
+    // If the link is a string, this means that it is external
+    const isExternalLink = typeof props.link === 'string';
+
+    const linkAttributes = isExternalLink
+      ? { href: props.link, rel: 'noreferrer', target: '_blank' }
+      : {};
+
+    const content = (
+      <a // eslint-disable-line jsx-a11y/no-static-element-interactions
+        {...linkAttributes}
+        role="link"
+        className={classnames(classes)}
+      >
+        {props.children}
+      </a>
+    );
+
+    if (isExternalLink) {
+      return content;
+    }
+
+    return (
+      <Link route={props.link.route} params={props.link.params}>
+        {content}
+      </Link>
+    );
+  }
+
+  // We render a real button
+  return (
+    <button
+      className={classnames(classes)}
+      type="button"
+      onClick={props.onClick}
+    >
+      {props.children}
+    </button>
+  );
+}
+
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  link: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      route: PropTypes.string.isRequired,
+      params: PropTypes.object
+    })
+  ]),
+  onClick: PropTypes.func,
+  secondary: PropTypes.bool,
+  inverse: PropTypes.bool
+};
+
+Button.defaultProps = {
+  secondary: false,
+  inverse: false
+};

--- a/components/common/Button.js
+++ b/components/common/Button.js
@@ -4,13 +4,12 @@ import classnames from 'classnames';
 import { Link } from 'routes';
 
 export default function Button(props) {
-  const classes = ['c-button'];
-
-  // We add the classes
-  if (props.secondary) classes.push('-secondary');
-  else classes.push('-primary');
-
-  if (props.inverse) classes.push('-inverse');
+  const classes = classnames({
+    'c-button': true,
+    '-primary': !props.secondary,
+    '-secondary': props.secondary,
+    '-inverse': props.inverse
+  });
 
   if (props.link) {
     // If the link is a string, this means that it is external
@@ -24,7 +23,7 @@ export default function Button(props) {
       <a // eslint-disable-line jsx-a11y/no-static-element-interactions
         {...linkAttributes}
         role="link"
-        className={classnames(classes)}
+        className={classes}
       >
         {props.children}
       </a>

--- a/css/components/common/_button.scss
+++ b/css/components/common/_button.scss
@@ -7,6 +7,7 @@
   line-height: 1;
   text-decoration: none;
   text-transform: uppercase;
+  cursor: pointer;
 
   &.-primary {
     color: $color-text-4;
@@ -28,5 +29,10 @@
       color: $color-text-4;
       border: 1px solid $color-white;
     }
+  }
+
+  &.-disabled {
+    opacity: .3;
+    pointer-events: none;
   }
 }

--- a/css/components/common/_button.scss
+++ b/css/components/common/_button.scss
@@ -1,0 +1,32 @@
+.c-button {
+  display: inline-block;
+  padding: 8px 15px 7px;
+  background-color: transparent;
+  border-radius: 15px;
+  font-size: $font-size-smaller;
+  line-height: 1;
+  text-decoration: none;
+  text-transform: uppercase;
+
+  &.-primary {
+    color: $color-text-4;
+    background-color: $color-1;
+    border: 1px solid $color-1;
+
+    &.-inverse {
+      color: $color-text-1;
+      background-color: $color-white;
+      border: 1px solid $color-white;
+    }
+  }
+
+  &.-secondary {
+    color: $color-text-1;
+    border: 1px solid $color-4;
+
+    &.-inverse {
+      color: $color-text-4;
+      border: 1px solid $color-white;
+    }
+  }
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -34,3 +34,4 @@
 @import 'components/common/grid-slider';
 @import 'components/common/cover';
 @import 'components/common/breadcrumbs';
+@import 'components/common/button';


### PR DESCRIPTION
This PR adds the `Button` component.

<p align="center">
<img width="184" alt="Screenshot of the combinations of style for the component" src="https://user-images.githubusercontent.com/6073968/27346569-8dc32d58-55e5-11e7-9c4a-8a738c820d8d.png">
</p>

Four combinations of styles are available. From top to bottom, this is how the buttons have been rendered:
- `<Button>Hey!</Button>`
- `<Button secondary>Hey!</Button>`
- `<Button inverse>Hey!</Button>`
- `<Button secondary inverse>Hey!</Button>`

The buttons can be either real buttons or links:
- if buttons, you can use the prop `onClick` to know when they've been clicked.
- if links, you can either pass a URL (prop `link`) or a route configuration (prop `link` with, for example, the following object `{ route: 'explore-index', params: { category: 'solutions' } }`.