### PR TITLE
Fixes broken develop

### DIFF
--- a/modules/bme.js
+++ b/modules/bme.js
@@ -57,7 +57,6 @@ export function getBmes(filters = {}) {
   const includeParams = ['children', 'children.bmes', 'children.children.bmes'];
 
   const queryParams = queryString.stringify({
-    'filter[level]': 1,
     'filter[slug]': subCategory || category || undefined,
     include: includeParams.join(','),
     'page[size]': 1000

--- a/utils/bme.js
+++ b/utils/bme.js
@@ -3,6 +3,7 @@
 const listBmes = bmes => bmes.map(bme => ({
   id: bme.id,
   title: bme.name,
+  image: bme.photos && bme.photos[0] ? `${process.env.API_URL}${bme.photos[0].attachment.medium.url}` : null,
   link: { route: 'bme-detail', params: { id: bme.id } }
 }));
 
@@ -15,7 +16,7 @@ const listsBmesByCategory = (categories, filters = {}) =>
     title: category.name,
     level: category.level,
     slug: category.slug,
-    image: bme.photos && bme.photos[0] ? `${process.env.API_URL}${bme.photos[0].attachment.medium.url}` : null,
+    image: category.photos && category.photos[0] ? `${process.env.API_URL}${category.photos[0].attachment.medium.url}` : null,
     children: listBmes(category['children-bmes'] || [])
   }
 ));


### PR DESCRIPTION
@hugopeixoto I see you added a `filter[level]: 1,` param in the BME call. This will work for you, but it doesn't for the explore section so I would recommend make this filter conditional or create another action for the builder.