### PR TITLE
Bugfix/reduce chart size on smaller screens

### DIFF
--- a/components/builder-index/EnablingConditionsSelector.js
+++ b/components/builder-index/EnablingConditionsSelector.js
@@ -9,7 +9,7 @@ class EnablingConditionsSelector extends React.Component {
     super();
 
     this.state = {
-      activeTab: null,
+      activeTab: 0,
     };
   }
 
@@ -18,6 +18,8 @@ class EnablingConditionsSelector extends React.Component {
   }
 
   render() {
+    const isActive = (index) => this.state.activeTab === index;
+
     return (
       <div className="c-enabling-conditions-selector">
         <header>
@@ -34,8 +36,8 @@ class EnablingConditionsSelector extends React.Component {
                   {this.props.nodes.map((node, i) => (
                     <li
                       key={node.slug}
-                      className={classnames("tab-item", { "-current": (this.state.activeTab === null && i === 0) || this.state.activeTab == node.slug})}
-                      onClick={() => this.selectTab(node.slug)}
+                      className={classnames("tab-item", { "-current": isActive(i)})}
+                      onClick={() => this.selectTab(i)}
                     >
                       <span className="literal">{node.name}</span>
                     </li>
@@ -49,7 +51,7 @@ class EnablingConditionsSelector extends React.Component {
           <h2 className="c-title -fw-light -fs-bigger">No enabling conditions available</h2>
         </section>}
 
-        {this.props.nodes.filter((node, i) => (this.state.activeTab === null && i === 0) || this.state.activeTab == node.slug).map(node => (
+        {this.props.nodes.filter((node, i) => isActive(i)).map(node => (
           <section key={node.id}>
             {node.children.map(subnode => (
               <div key={subnode.id}>
@@ -59,7 +61,11 @@ class EnablingConditionsSelector extends React.Component {
 
                 <ul>
                   {subnode.children.map(enabling => (
-                    <li key={enabling.id}>
+                    <li
+                      key={enabling.id}
+                      onMouseEnter={() => this.props.onEnablingHover(enabling)}
+                      onMouseLeave={() => this.props.onEnablingHover({})}
+                    >
                       <EnablingCheckbox
                         checked={this.props.selectedEnablings.includes(enabling.id)}
                         enabling={enabling}

--- a/components/common/RadialChart.js
+++ b/components/common/RadialChart.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from  'prop-types';
 import classnames from 'classnames';
 
-const depths = [140, 260, 320, 485];
+const depths = [140, 260, 320, 455];
 const sizes = [80, 15, 5, 6];
 
 const distanceBetween = (p0, p1) => Math.sqrt((p1.y - p0.y)**2 + (p1.x - p0.x)**2);
@@ -179,7 +179,7 @@ class RadialChart extends React.Component {
     super();
 
     this.state = {
-      scale: 0.7,
+      scale: 1,
       x: 0,
       zooming: false,
     }
@@ -201,7 +201,7 @@ class RadialChart extends React.Component {
       } else if (node.family == this.state.family) {
         this.setState({
           x: 0,
-          scale: 0.7,
+          scale: 1,
           family: null,
           zooming: true,
         });
@@ -270,7 +270,7 @@ class RadialChart extends React.Component {
         <div className={classnames("u-relative", `active-${this.state.family || "none"}`)}>
           <svg id="chart" className="u-block" viewBox="0 0 1000 1000">
             <g transform={`scale(${this.state.scale})`} onTransitionEnd={() => this.transitionEnd()} />
-            <g transform={`translate(${this.state.x + 500} 430) scale(${this.state.scale})`}>
+            <g transform={`translate(${this.state.x + 500} 500) scale(${this.state.scale})`}>
               {nodes.map(node => (
                 <node.component
                   {...node.props}
@@ -288,8 +288,8 @@ class RadialChart extends React.Component {
             <div className={`root-label ${node.family}`} key={`label-${node.id}`} style={{
               opacity: this.state.zooming ? 0 : "",
               position: "absolute",
-              top: `${(node.y * this.state.scale + 355)/1000.0*100}%`,
-              left: `${(node.x * this.state.scale + 425 + this.state.x)/1000.0*100}%`,
+              top: `${(node.y * this.state.scale + 500)/1000.0*100}%`,
+              left: `${(node.x * this.state.scale + this.state.x + 500)/1000.0*100}%`,
             }}>
               <p>{node.name}</p>
             </div>

--- a/css/components/page/builder-index/_layout.scss
+++ b/css/components/page/builder-index/_layout.scss
@@ -129,7 +129,6 @@
 
 .radial-chart {
   &.thumbnail {
-    width: 340px;
     margin-left: auto;
     padding-top: 100px;
 

--- a/css/components/page/builder-index/_layout.scss
+++ b/css/components/page/builder-index/_layout.scss
@@ -135,11 +135,12 @@
     p {
       display: none;
     }
+    width: auto;
   }
 
   font-weight: 300;
   position: relative;
-  //width: 1080px;
+  max-width: 80vh;
 
   .tooltip {
     z-index: $z-index-11;
@@ -246,8 +247,21 @@
   }
 }
 
-.root-label { width: 15%; height: 15%; margin: 0; display: flex; align-items: center; pointer-events: none; padding: 2%; }
-.root-label p { text-align: center; width: 100%; }
+.root-label {
+  width: 16%;
+  height: 16%;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+
+  transform: translate(-50%, -50%);
+
+  p {
+    text-align: center;
+    width: 100%;
+  }
+}
 
 
 .enabling-conditions .radial-chart {

--- a/css/utils.scss
+++ b/css/utils.scss
@@ -22,6 +22,7 @@
 .u-mb-1\/2 { margin-bottom: 0.5em; }
 .u-ml-1 { margin-left: 1em; }
 .u-mr-1 { margin-right: 1em; }
+.u-ml-a { margin-left: auto; }
 
 .u-flex-column {
   display: flex;
@@ -30,6 +31,7 @@
 }
 
 .u-w-100 { width: 100%; }
+.u-w-30 { width: 30%; }
 .u-w-bl { width: #{$base-line-height}em; }
 .u-h-bl { height: #{$base-line-height}em; }
 

--- a/pages/builder/BuilderIndex.js
+++ b/pages/builder/BuilderIndex.js
@@ -1,9 +1,10 @@
-import Page from 'pages/Page';
+import classnames from 'classnames';
 import flatMap from 'lodash/flatMap';
 import uniq from 'lodash/uniq';
 import intersection from 'lodash/intersection';
 import storage from 'local-storage-fallback';
 
+import Page from 'pages/Page';
 import Layout from 'components/layout/layout';
 import Sidebar from 'components/builder-index/Sidebar';
 import SolutionPicker from 'components/builder-index/SolutionPicker';
@@ -55,8 +56,9 @@ class BuilderIndex extends Page {
     super();
 
     this.state = {
-      sidebar: "default",
+      sidebar: "enablings",
       showHelp: process.browser && !storage.getItem('builder.help-dismissed'),
+      hoveredEnabling: null,
     };
   }
 
@@ -136,6 +138,10 @@ class BuilderIndex extends Page {
     this.props.reset();
   }
 
+  showEnablingBMEs(enabling) {
+    this.setState({ hoveredEnabling: enabling.id });
+  }
+
   render() {
     return (
       <Layout
@@ -168,10 +174,15 @@ class BuilderIndex extends Page {
           onClose={() => this.showSidebar()}
           onEnablingSelect={(enabling) => this.selectEnabling(enabling)}
           onEnablingDeselect={(enabling) => this.deselectEnabling(enabling)}
+          onEnablingHover={(enabling) => this.showEnablingBMEs(enabling)}
         />
         }
 
-        <div className="u-w-100 u-mt-2">
+        <div className={classnames(
+          "u-mt-2",
+          "u-ml-a",
+          this.state.sidebar == "enablings" ? "u-w-30" : "u-w-100",
+        )}>
           <RadialChart
             nodes={this.props.categories}
             selected={this.props.selectedBMEs}
@@ -180,6 +191,20 @@ class BuilderIndex extends Page {
             interactive={this.state.sidebar == "default"}
             thumbnail={this.state.sidebar == "enablings"}
           />
+
+          { this.state.hoveredEnabling &&
+              <div className="u-ml-1">
+                <h1 className="c-title -fw-light -fs-bigger">Success factor for</h1>
+
+                <ul>
+                  {
+                    leaves(this.props.categories).
+                      filter(bme => bme.enablings.find(enabling => enabling && enabling.id == this.state.hoveredEnabling)).
+                      map(bme => <li className="c-text -fs-smaller -uppercase">{bme.name}</li>)
+                  }
+                </ul>
+              </div>
+          }
         </div>
 
         {this.state.bme && <BmeDetail


### PR DESCRIPTION
This wasn't working great. The chart was resizing based on the browser width.
Its width is now proportional to the viewport height.