### PR TITLE
Allow solution deselection after saving

### DIFF
--- a/modules/builder.js
+++ b/modules/builder.js
@@ -85,7 +85,7 @@ const sliceReducer = (state = initialSliceState, action) => {
         ...state,
         title: action.project.title,
         description: action.project.description,
-        selectedSolution: action.project['solution-id'].toString(),
+        selectedSolution: action.project['solution-id'] && action.project['solution-id'].toString(),
 
         selectedBMEs: publicBmBmes.map(bmbme => bmbme.bme.id),
         commentedBMEs: fromPairs(

--- a/modules/builder.js
+++ b/modules/builder.js
@@ -271,7 +271,7 @@ export function update(_, project, authToken) {
   const params = {
     title: project.title,
     description: project.description,
-    solution_id: project.selectedSolution,
+    solution_id: project.selectedSolution || null,
     enabling_ids: project.selectedEnablings,
     business_model_bmes_attributes: [].concat(
       project.selectedBMEs.map(bmeId => ({


### PR DESCRIPTION
After saving, if a solution had been selected, we were unable to revert to "All solutions" and save that change.